### PR TITLE
Fix PWA icon format - switch from PNG to SVG icons

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,12 +39,12 @@ export const metadata: Metadata = {
   },
   icons: {
     icon: [
-      { url: "/icons/icon-192x192.png", sizes: "192x192", type: "image/png" },
-      { url: "/icons/icon-512x512.png", sizes: "512x512", type: "image/png" },
+      { url: "/icons/icon-192x192.svg", sizes: "192x192", type: "image/svg+xml" },
+      { url: "/icons/icon-512x512.svg", sizes: "512x512", type: "image/svg+xml" },
     ],
     apple: [
-      { url: "/icons/icon-152x152.png", sizes: "152x152", type: "image/png" },
-      { url: "/icons/icon-180x180.png", sizes: "180x180", type: "image/png" },
+      { url: "/icons/icon-152x152.svg", sizes: "152x152", type: "image/svg+xml" },
+      { url: "/icons/icon-180x180.svg", sizes: "180x180", type: "image/svg+xml" },
     ],
   },
 };

--- a/public/icons/icon-128x128.png
+++ b/public/icons/icon-128x128.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="51.2" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-144x144.png
+++ b/public/icons/icon-144x144.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">
-  <rect width="144" height="144" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="57.6" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-152x152.png
+++ b/public/icons/icon-152x152.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="152" height="152" viewBox="0 0 152 152">
-  <rect width="152" height="152" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="60.800000000000004" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-180x180.png
+++ b/public/icons/icon-180x180.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
-  <rect width="192" height="192" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="76.80000000000001" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-192x192.png
+++ b/public/icons/icon-192x192.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
-  <rect width="192" height="192" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="76.80000000000001" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-384x384.png
+++ b/public/icons/icon-384x384.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="384" height="384" viewBox="0 0 384 384">
-  <rect width="384" height="384" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="153.60000000000002" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-512x512.png
+++ b/public/icons/icon-512x512.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
-  <rect width="512" height="512" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="204.8" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-72x72.png
+++ b/public/icons/icon-72x72.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 72 72">
-  <rect width="72" height="72" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="28.8" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/icons/icon-96x96.png
+++ b/public/icons/icon-96x96.png
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
-  <rect width="96" height="96" fill="#000000"/>
-  <text x="50%" y="50%" font-family="Arial, sans-serif" font-size="38.400000000000006" font-weight="bold" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">TL</text>
-</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,66 +9,28 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
+      "src": "/icons/icon-192x192.svg",
       "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "type": "image/svg+xml",
+      "purpose": "any"
     },
     {
-      "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
+      "src": "/icons/icon-512x512.svg",
       "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
-    }
-  ],
-  "screenshots": [
-    {
-      "src": "/screenshots/screenshot-wide.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide"
+      "type": "image/svg+xml",
+      "purpose": "any"
     },
     {
-      "src": "/screenshots/screenshot-narrow.png",
-      "sizes": "750x1334",
-      "type": "image/png",
-      "form_factor": "narrow"
+      "src": "/icons/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icons/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ],
   "categories": ["productivity", "utilities"],


### PR DESCRIPTION
- Removed fake PNG icon files (were actually SVG files renamed)
- Updated manifest.json to reference SVG icons properly
- Updated layout.tsx icon references to use SVG format
- Removed screenshot references from manifest (not yet created)

This fixes the Vercel deployment issue where PNG files were causing problems.