### PR TITLE
Test deployment without PWA to isolate issue

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,4 @@
 import type { NextConfig } from "next";
-import withPWAInit from "@ducanh2912/next-pwa";
-
-const withPWA = withPWAInit({
-	dest: "public",
-	cacheOnFrontEndNav: true,
-	aggressiveFrontEndNavCaching: true,
-	reloadOnOnline: true,
-	swcMinify: true,
-	disable: process.env.NODE_ENV === "development",
-	workboxOptions: {
-		disableDevLogs: true,
-	},
-});
 
 const nextConfig: NextConfig = {
 	/* config options here */
@@ -38,4 +25,4 @@ const nextConfig: NextConfig = {
 	},
 };
 
-export default withPWA(nextConfig);
+export default nextConfig;


### PR DESCRIPTION
Temporarily disabled PWA configuration to test if Vercel deployment succeeds without it. This will help diagnose whether the deployment issue is PWA-related or a broader Vercel platform problem.

Changes:
- Removed @ducanh2912/next-pwa wrapper from next.config.ts
- App still has manifest.json and icons
- Service worker will not be generated

If this deploys successfully, we know the issue is PWA-related. If it still fails, it's a broader Vercel infrastructure issue.